### PR TITLE
Release for v0.0.3

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - rcpr

--- a/.rcpr
+++ b/.rcpr
@@ -1,0 +1,27 @@
+# config file for the rcpr in git config format
+# The rcpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   rcpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The pcpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   rcpr.versinFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#
+#   rcpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   rcpr.command (Optional)
+#       Command to change files just before release.
+#
+#   rcpr.tmplate (Optional)
+#       Pull request template in go template format
+[rcpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = version.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.3](https://github.com/Songmu/gitsemvers/compare/v0.0.2...v0.0.3) - 2022-08-27
+- introduce rcpr by @Songmu in https://github.com/Songmu/gitsemvers/pull/4
+- update releng by @Songmu in https://github.com/Songmu/gitsemvers/pull/6
+
 ## [v0.0.2](https://github.com/Songmu/gitsemvers/compare/v0.0.1...v0.0.2) (2022-08-15)
 
 * use golang.org/x/mod/semver instead of MasterMinds/semver [#3](https://github.com/Songmu/gitsemvers/pull/3) ([Songmu](https://github.com/Songmu))

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package gitsemvers
 
-const version = "0.0.2"
+const version = "0.0.3"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.0.3 created by [rcpr](https://github.com/Songmu/rcpr). Merging it will tag v0.0.3 to the merge commit and create a GitHub release.

You can modify this branch "rcpr-from-v0.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .rcpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "rcpr:minor" or "rcpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* introduce rcpr by @Songmu in https://github.com/Songmu/gitsemvers/pull/4
* update releng by @Songmu in https://github.com/Songmu/gitsemvers/pull/6


**Full Changelog**: https://github.com/Songmu/gitsemvers/compare/v0.0.2...v0.0.3