### PR TITLE
Release for v0.1.0

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,51 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release and versioning.
+#
+#   tagpr.postVersionCommand (Optional)
+#       Command to change files just after versioning.
+#
+#   tagpr.template (Optional)
+#       Pull request template file in go template format
+#
+#   tagpr.templateText (Optional)
+#       Pull request template text in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+#   tagpr.commitPrefix (Optional)
+#       Prefix of commit message. Default is "[tagpr]"
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = version.go

--- a/.tagpr
+++ b/.tagpr
@@ -1,51 +1,5 @@
-# config file for the tagpr in git config format
-# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
-# CONFIGURATIONS:
-#   tagpr.releaseBranch
-#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
-#       creates or updates a pull request as a release candidate, or tags when they are merged.
-#
-#   tagpr.versionFile
-#       Versioning file containing the semantic version needed to be updated at release.
-#       It will be synchronized with the "git tag".
-#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
-#       Sometimes the source code file, such as version.go or Bar.pm, is used.
-#       If you do not want to use versioning files but only git tags, specify the "-" string here.
-#       You can specify multiple version files by comma separated strings.
-#
-#   tagpr.vPrefix
-#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
-#       This is only a tagging convention, not how it is described in the version file.
-#
-#   tagpr.changelog (Optional)
-#       Flag whether or not changelog is added or changed during the release.
-#
-#   tagpr.command (Optional)
-#       Command to change files just before release and versioning.
-#
-#   tagpr.postVersionCommand (Optional)
-#       Command to change files just after versioning.
-#
-#   tagpr.template (Optional)
-#       Pull request template file in go template format
-#
-#   tagpr.templateText (Optional)
-#       Pull request template text in go template format
-#
-#   tagpr.release (Optional)
-#       GitHub Release creation behavior after tagging [true, draft, false]
-#       If this value is not set, the release is to be created.
-#
-#   tagpr.majorLabels (Optional)
-#       Label of major update targets. Default is [major]
-#
-#   tagpr.minorLabels (Optional)
-#       Label of minor update targets. Default is [minor]
-#
-#   tagpr.commitPrefix (Optional)
-#       Prefix of commit message. Default is "[tagpr]"
-#
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
 	versionFile = version.go
+	release = draft

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v0.1.0](https://github.com/Songmu/gitsemvers/compare/v0.0.3...v0.1.0) - 2025-12-21
+- s/rcpr/tagpr/ by @Songmu in https://github.com/Songmu/gitsemvers/pull/7
+- feat: add TagPrefix support for monorepo by @biosugar0 in https://github.com/Songmu/gitsemvers/pull/10
+- Bump codecov/codecov-action from 1 to 5 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/17
+- Bump actions/checkout from 3 to 6 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/16
+- Bump actions/setup-go from 3 to 6 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/12
+- Bump golang.org/x/mod from 0.5.1 to 0.31.0 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/14
+- Drop jessevdk/go-flags dependency by @Songmu in https://github.com/Songmu/gitsemvers/pull/18
+- introduce tagpr by @Songmu in https://github.com/Songmu/gitsemvers/pull/11
+- introduce pinact and ghalint by @Songmu in https://github.com/Songmu/gitsemvers/pull/19
+
 ## [v0.0.3](https://github.com/Songmu/gitsemvers/compare/v0.0.2...v0.0.3) - 2022-08-27
 - introduce rcpr by @Songmu in https://github.com/Songmu/gitsemvers/pull/4
 - update releng by @Songmu in https://github.com/Songmu/gitsemvers/pull/6

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package gitsemvers
 
-const Version = "0.0.3"
+const Version = "0.1.0"
 
 var Revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* s/rcpr/tagpr/ by @Songmu in https://github.com/Songmu/gitsemvers/pull/7
* feat: add TagPrefix support for monorepo by @biosugar0 in https://github.com/Songmu/gitsemvers/pull/10
* Bump codecov/codecov-action from 1 to 5 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/17
* Bump actions/checkout from 3 to 6 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/16
* Bump actions/setup-go from 3 to 6 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/12
* Bump golang.org/x/mod from 0.5.1 to 0.31.0 by @dependabot[bot] in https://github.com/Songmu/gitsemvers/pull/14
* Drop jessevdk/go-flags dependency by @Songmu in https://github.com/Songmu/gitsemvers/pull/18
* introduce tagpr by @Songmu in https://github.com/Songmu/gitsemvers/pull/11
* introduce pinact and ghalint by @Songmu in https://github.com/Songmu/gitsemvers/pull/19

## New Contributors
* @biosugar0 made their first contribution in https://github.com/Songmu/gitsemvers/pull/10
* @dependabot[bot] made their first contribution in https://github.com/Songmu/gitsemvers/pull/17

**Full Changelog**: https://github.com/Songmu/gitsemvers/compare/v0.0.3...tagpr-from-v0.0.3