### PR TITLE
feat: add TagPrefix support for monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ sv := &gitsemvers.Semvers{RepoPath: "path/to/repo"}
 semvers := sv.VersionStrings()
 ```
 
+### Monorepo Support
+
+For monorepo projects with prefixed tags (e.g., `tools/v1.0.0`):
+
+```go
+sv := &gitsemvers.Semvers{
+    RepoPath:  "path/to/repo",
+    TagPrefix: "tools",
+}
+semvers := sv.VersionStrings() // returns ["tools/v1.1.0", "tools/v1.0.0", ...]
+```
+
 ## Command Line Tool
 
     % go get github.com/Songmu/gitsemvers/cmd/git-semvers

--- a/gitsemvers_test.go
+++ b/gitsemvers_test.go
@@ -78,6 +78,56 @@ func TestParseVersionsWithAllExtensions(t *testing.T) {
 	}
 }
 
+func TestParseVersionsWithTagPrefix(t *testing.T) {
+	input := "tools/v1.1.0\ntools/v1.0.0\nother/v2.0.0\nv3.0.0\ninvalid"
+	sv := &Semvers{TagPrefix: "tools"}
+	got := sv.parseVersions(input)
+	want := []string{"tools/v1.1.0", "tools/v1.0.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseVersionsWithTagPrefixTrailingSlash(t *testing.T) {
+	input := "tools/v1.0.0\ntools/v0.9.0"
+	sv := &Semvers{TagPrefix: "tools/"}
+	got := sv.parseVersions(input)
+	want := []string{"tools/v1.0.0", "tools/v0.9.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseVersionsWithNestedTagPrefix(t *testing.T) {
+	input := "tools/cli/v1.0.0\ntools/cli/v0.9.0\ntools/v1.0.0"
+	sv := &Semvers{TagPrefix: "tools/cli"}
+	got := sv.parseVersions(input)
+	want := []string{"tools/cli/v1.0.0", "tools/cli/v0.9.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseVersionsWithTagPrefixAndPreRelease(t *testing.T) {
+	input := "tools/v1.0.0\ntools/v1.0.0-beta\ntools/v0.9.0"
+	sv := &Semvers{TagPrefix: "tools", WithPreRelease: true}
+	got := sv.parseVersions(input)
+	want := []string{"tools/v1.0.0", "tools/v1.0.0-beta", "tools/v0.9.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseVersionsWithTagPrefixNoVPrefix(t *testing.T) {
+	input := "tools/1.0.0\ntools/0.9.0"
+	sv := &Semvers{TagPrefix: "tools"}
+	got := sv.parseVersions(input)
+	want := []string{"tools/1.0.0", "tools/0.9.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
 func TestVersionStrings(t *testing.T) {
 	gm, err := gitmock.New("")
 	if err != nil {


### PR DESCRIPTION
First of all, thank you for creating and maintaining this awesome project! 🙏

### Summary

Add `TagPrefix` field to `Semvers` struct to filter tags by prefix.
This enables monorepo support with prefixed tags like `tools/v1.0.0`.

### Motivation

This change is a prerequisite for adding monorepo support to tagpr ([Songmu/tagpr#210](https://github.com/Songmu/tagpr/issues/210)).

For example, Go modules in a monorepo require tags in `<subdir>/vX.Y.Z` format (e.g., `tools/v1.0.0`).
By adding prefix filtering to gitsemvers, tagpr can properly detect the latest version for each module in a monorepo.

### Usage

```go
sv := &gitsemvers.Semvers{
    RepoPath:  "path/to/repo",
    TagPrefix: "tools",
}
semvers := sv.VersionStrings() // ["tools/v1.1.0", "tools/v1.0.0", ...]
```

CLI:
```bash
git-semvers --prefix tools
```

### Changes

- Add `TagPrefix` field with `-p`, `--prefix` CLI flag
- Filter tags by prefix in `parseVersions()`
- Return original tag names (with prefix) in semver-sorted order